### PR TITLE
allow 512mib sectors & fake PoSt proofs to long term runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v0.2.3
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/lotus v0.3.1-0.20200520104953-cea7c410235b
-	github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52
+	github.com/filecoin-project/sector-storage v0.0.0-20200520143055-21f02924c16a
 	github.com/filecoin-project/specs-actors v0.5.3
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log/v2 v2.0.5

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef
 	github.com/filecoin-project/go-fil-markets v0.2.3
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
-	github.com/filecoin-project/lotus v0.3.0
+	github.com/filecoin-project/lotus v0.3.1-0.20200520104953-cea7c410235b
 	github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52
 	github.com/filecoin-project/specs-actors v0.5.3
 	github.com/ipfs/go-datastore v0.4.4

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v0.2.3
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/lotus v0.3.0
-	github.com/filecoin-project/sector-storage v0.0.0-20200513185232-4051533cc4bd
+	github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52
 	github.com/filecoin-project/specs-actors v0.5.3
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log/v2 v2.0.5
@@ -21,3 +21,7 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
+
+// Notes:
+// - filecoin-ffi is using a non-derived dep version from Lotus: bad file descriptor fix.
+// - sector-storage is using a non-derived dep version from Lotus: fake PoSt proof fix.

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/filecoin-project/sector-storage v0.0.0-20200513185232-4051533cc4bd/go
 github.com/filecoin-project/sector-storage v0.0.0-20200515123304-20817dc51db5/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
 github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52 h1:3Nbxeqiw3865IoLtEnZOjFG8upN7uZEz+ytM4TeZNsg=
 github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
+github.com/filecoin-project/sector-storage v0.0.0-20200520143055-21f02924c16a h1:g5rPAwVosXcJoGxa1qhBmZlmwT6FeQjbtGTa3kNcQNE=
+github.com/filecoin-project/sector-storage v0.0.0-20200520143055-21f02924c16a/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504/go.mod h1:mdJraXq5vMy0+/FqVQIrnNlpQ/Em6zeu06G/ltQ0/lA=
 github.com/filecoin-project/specs-actors v0.2.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/filecoin-project/sector-storage v0.0.0-20200411000242-61616264b16d/go
 github.com/filecoin-project/sector-storage v0.0.0-20200508203401-a74812ba12f3/go.mod h1:B+xzopr/oWZJz2hBL5Ekb7Obcum5ntmfbaAUlaaho28=
 github.com/filecoin-project/sector-storage v0.0.0-20200513185232-4051533cc4bd h1:CPzpRRooX7cI0g04GJo5mHTE8PpnUwCJBC1ZPGd2kRA=
 github.com/filecoin-project/sector-storage v0.0.0-20200513185232-4051533cc4bd/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
+github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52 h1:3Nbxeqiw3865IoLtEnZOjFG8upN7uZEz+ytM4TeZNsg=
+github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504/go.mod h1:mdJraXq5vMy0+/FqVQIrnNlpQ/Em6zeu06G/ltQ0/lA=
 github.com/filecoin-project/specs-actors v0.2.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/drand/bls12-381 v0.3.2 h1:RImU8Wckmx8XQx1tp1q04OV73J9Tj6mmpQLYDP7V1XE
 github.com/drand/bls12-381 v0.3.2/go.mod h1:dtcLgPtYT38L3NO6mPDYH0nbpc5tjPassDqiniuAt4Y=
 github.com/drand/drand v0.8.1 h1:wAGnZKa+HbyNvRQOwLGIVnJR14o9kS/0+w9VroJ1AO0=
 github.com/drand/drand v0.8.1/go.mod h1:ZdzIrSqqEYZvMiS1UuZlJs3WTb9uLz1I9uH0icYPqoE=
+github.com/drand/drand v0.8.2-0.20200518165838-d61135e6e2c8 h1:i5Dh4bklVI1mRLflpOJa5igk6xdPJWgZAe8iesZSs0o=
+github.com/drand/drand v0.8.2-0.20200518165838-d61135e6e2c8/go.mod h1:ZdzIrSqqEYZvMiS1UuZlJs3WTb9uLz1I9uH0icYPqoE=
 github.com/drand/kyber v1.0.1-0.20200110225416-8de27ed8c0e2/go.mod h1:UpXoA0Upd1N9l4TvRPHr1qAUBBERj6JQ/mnKI3BPEmw=
 github.com/drand/kyber v1.0.1-0.20200331114745-30e90cc60f99 h1:BxLbcT0yq9ii6ShXn7U+0oXB2ABfEfw6GutaVPxoj2Y=
 github.com/drand/kyber v1.0.1-0.20200331114745-30e90cc60f99/go.mod h1:Rzu9PGFt3q8d7WWdrHmR8dktHucO0dSTWlMYrgqjSpA=
@@ -135,6 +137,7 @@ github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6
 github.com/filecoin-project/chain-validation v0.0.3/go.mod h1:NCEGFjcWRjb8akWFSOXvU6n2efkWIqAeOKU6o5WBGQw=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200512234642-6304037e1db6 h1:uw5MU6Rz10zvi3ZjmdbsJ55HgISsWWUJtONgbZiglPg=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200512234642-6304037e1db6/go.mod h1:rk37vy27b6fmE+PJYjKfyBjm8VjSojkWDiu+Xf3ss1A=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200518190139-483332336e8e/go.mod h1:6B3uenDcH8n+PKqgzUtZmgyCzKy4qpiLwJ5aw7Rj2xQ=
 github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f/go.mod h1:rCbpXPva2NKF9/J4X6sr7hbKBgQCxyFtRj7KOZqoIms=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
@@ -188,10 +191,13 @@ github.com/filecoin-project/lotus v0.2.10 h1:ijrj/nYdKu5GiMo9r1+Zcp2A4jKHSOMZ2WN
 github.com/filecoin-project/lotus v0.2.10/go.mod h1:om5PQA9ZT0lf16qI7Fz/ZGLn4LDCMqPC8ntZA9uncRE=
 github.com/filecoin-project/lotus v0.3.0 h1:M9V88rma9BNg3XGQFNwGQWMBmDN+QSwEU0vULlTBzog=
 github.com/filecoin-project/lotus v0.3.0/go.mod h1:KfBh4IrTBICpgLLswmTd6kiWVvjl9ED18dtyopUcCzc=
+github.com/filecoin-project/lotus v0.3.1-0.20200520104953-cea7c410235b h1:glGWivfOfWOmQ+Vvx51yTrbsr6sfUy/yqp/SkBtazEo=
+github.com/filecoin-project/lotus v0.3.1-0.20200520104953-cea7c410235b/go.mod h1:TGiA8C9Nw0mCdO66V6rQowrX5ti/t0dr7wwaIkow6+I=
 github.com/filecoin-project/sector-storage v0.0.0-20200411000242-61616264b16d/go.mod h1:/yueJueMh0Yc+0G1adS0lhnedcSnjY86EjKsA20+DVY=
 github.com/filecoin-project/sector-storage v0.0.0-20200508203401-a74812ba12f3/go.mod h1:B+xzopr/oWZJz2hBL5Ekb7Obcum5ntmfbaAUlaaho28=
 github.com/filecoin-project/sector-storage v0.0.0-20200513185232-4051533cc4bd h1:CPzpRRooX7cI0g04GJo5mHTE8PpnUwCJBC1ZPGd2kRA=
 github.com/filecoin-project/sector-storage v0.0.0-20200513185232-4051533cc4bd/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
+github.com/filecoin-project/sector-storage v0.0.0-20200515123304-20817dc51db5/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
 github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52 h1:3Nbxeqiw3865IoLtEnZOjFG8upN7uZEz+ytM4TeZNsg=
 github.com/filecoin-project/sector-storage v0.0.0-20200520005031-ca37a9086f52/go.mod h1:AeiT6Szz4XSnSJwHF1+flTRMspkwekbTP8zX8/wlhbY=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
@@ -202,6 +208,7 @@ github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVl
 github.com/filecoin-project/specs-actors v0.4.1-0.20200508202406-42be6629284d/go.mod h1:UW3ft23q6VS8wQoNqLWjENsu9gu1uh6lxOd+H8cwhT8=
 github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d/go.mod h1:UW3ft23q6VS8wQoNqLWjENsu9gu1uh6lxOd+H8cwhT8=
 github.com/filecoin-project/specs-actors v0.5.1/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
+github.com/filecoin-project/specs-actors v0.5.2/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
 github.com/filecoin-project/specs-actors v0.5.3 h1:fdq8Gx0izhnUKl6sYEtI4SUEjT2U6W2w06HeqLz5vmw=
 github.com/filecoin-project/specs-actors v0.5.3/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
 github.com/filecoin-project/specs-storage v0.0.0-20200410185809-9fbaaa08f275/go.mod h1:xJ1/xl9+8zZeSSSFmDC3Wr6uusCTxyYPI0VeNVSFmPE=
@@ -742,6 +749,8 @@ github.com/libp2p/go-libp2p-pubsub v0.2.6 h1:ypZaukCFrtD8cNeeb9nnWG4MD2Y1T0p22aQ
 github.com/libp2p/go-libp2p-pubsub v0.2.6/go.mod h1:5jEp7R3ItQ0pgcEMrPZYE9DQTg/H3CTc7Mu1j2G4Y5o=
 github.com/libp2p/go-libp2p-pubsub v0.2.7-0.20200505181014-5bbe37191afb h1:kVOUUt/ipiYgqB7t8qsUfs36o5ySZbShFL2BXICuRdU=
 github.com/libp2p/go-libp2p-pubsub v0.2.7-0.20200505181014-5bbe37191afb/go.mod h1:tFvkRgsW96JilTvYwe1X/lYqpruTXBqEatNXq3/MqBw=
+github.com/libp2p/go-libp2p-pubsub v0.2.7-0.20200513065812-9de0241df138 h1:6ZjQGfnsky0lcXE7uLVOX8/zMYYfEjfe/3+BKTcFjf0=
+github.com/libp2p/go-libp2p-pubsub v0.2.7-0.20200513065812-9de0241df138/go.mod h1:tFvkRgsW96JilTvYwe1X/lYqpruTXBqEatNXq3/MqBw=
 github.com/libp2p/go-libp2p-quic-transport v0.1.1 h1:MFMJzvsxIEDEVKzO89BnB/FgvMj9WI4GDGUW2ArDPUA=
 github.com/libp2p/go-libp2p-quic-transport v0.1.1/go.mod h1:wqG/jzhF3Pu2NrhJEvE+IE0NTHNXslOPn9JQzyCAxzU=
 github.com/libp2p/go-libp2p-record v0.0.1/go.mod h1:grzqg263Rug/sRex85QrDOLntdFAymLDLm7lxMgU79Q=

--- a/ldevnet/ldevnet.go
+++ b/ldevnet/ldevnet.go
@@ -56,7 +56,7 @@ const (
 func init() {
 	power.ConsensusMinerMinPower = big.NewInt(2048)
 	saminer.SupportedProofTypes = map[abi.RegisteredProof]struct{}{
-		abi.RegisteredProof_StackedDRG2KiBSeal: {},
+		abi.RegisteredProof_StackedDRG512MiBSeal: {},
 	}
 	verifreg.MinVerifiedDealSize = big.NewInt(256)
 	os.Setenv("TRUST_PARAMS", "1")
@@ -250,7 +250,7 @@ func mockSbBuilder(nFull int, storage []test.StorageMiner) ([]test.TestNode, []t
 			preseals = nGenesisPreseals
 		}
 
-		genm, k, err := mockstorage.PreSeal(2048, maddr, preseals)
+		genm, k, err := mockstorage.PreSeal(1024*1024*512, maddr, preseals)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -263,7 +263,7 @@ func mockSbBuilder(nFull int, storage []test.StorageMiner) ([]test.TestNode, []t
 
 		genaccs = append(genaccs, genesis.Actor{
 			Type:    genesis.TAccount,
-			Balance: big.Mul(big.NewInt(50000), types.NewInt(build.FilecoinPrecision)),
+			Balance: big.Mul(big.NewInt(500000), types.NewInt(build.FilecoinPrecision)),
 			Meta:    (&genesis.AccountMeta{Owner: wk.Address}).ActorMeta(),
 		})
 
@@ -276,7 +276,7 @@ func mockSbBuilder(nFull int, storage []test.StorageMiner) ([]test.TestNode, []t
 	templ := &genesis.Template{
 		Accounts:  genaccs,
 		Miners:    genms,
-		Timestamp: uint64(time.Now().Unix() - 10000),
+		Timestamp: uint64(time.Now().Add(-time.Hour * 100000).Unix()),
 	}
 
 	// END PRESEAL SECTION
@@ -327,9 +327,9 @@ func mockSbBuilder(nFull int, storage []test.StorageMiner) ([]test.TestNode, []t
 			node.Override(new(ffiwrapper.Verifier), mock.MockVerifier),
 			node.Unset(new(*sectorstorage.Manager)),
 		))
-		if err := storers[i].StorageMiner.MarketSetPrice(ctx, types.NewInt(1000)); err != nil {
-			return nil, nil, err
-		}
+		//if err := storers[i].StorageMiner.MarketSetPrice(ctx, types.NewInt(1000)); err != nil {
+		//	return nil, nil, err
+		//}
 	}
 
 	if err := mn.LinkAll(); err != nil {

--- a/ldevnet/ldevnet_test.go
+++ b/ldevnet/ldevnet_test.go
@@ -38,7 +38,7 @@ func TestStore(t *testing.T) {
 
 func dealSpecificMiner(t *testing.T, numMiners int, concreteMiner int) func(*testing.T) {
 	return func(t *testing.T) {
-		_, err := New(numMiners, time.Millisecond*250)
+		_, err := New(numMiners, time.Millisecond*100)
 		require.Nil(t, err)
 
 		var client apistruct.FullNodeStruct
@@ -71,7 +71,7 @@ func dealSpecificMiner(t *testing.T, numMiners int, concreteMiner int) func(*tes
 
 		r := rand.New(rand.NewSource(22))
 		for i := 0; i < 2; i++ {
-			data := make([]byte, 600)
+			data := make([]byte, 1024*1024*50)
 			r.Read(data)
 			err = ioutil.WriteFile(tmpf.Name(), data, 0644)
 			require.Nil(t, err)
@@ -82,7 +82,7 @@ func dealSpecificMiner(t *testing.T, numMiners int, concreteMiner int) func(*tes
 			sdp := &api.StartDealParams{
 				Data:              &storagemarket.DataRef{Root: fcid},
 				Wallet:            waddr,
-				EpochPrice:        types.NewInt(1000),
+				EpochPrice:        types.NewInt(100000000),
 				MinBlocksDuration: 100,
 				Miner:             miners[concreteMiner],
 			}


### PR DESCRIPTION
Allow 512Mib and also let devnet be long-running, required:
- https://github.com/filecoin-project/sector-storage/pull/38
- https://github.com/filecoin-project/sector-storage/pull/39
- https://github.com/filecoin-project/filecoin-ffi/pull/84

Presumably needs another PR in Lotus about `MarketSetPrice` which is reverting to 1Mib the `MaxPieceSize` config.